### PR TITLE
Adds missing setuptools import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import sys
 import platform
 import subprocess
 
+import setuptools
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion


### PR DESCRIPTION
Hi @DavidDiazGuerra , nice work on the GPU based RIR generation!

There was a missing `import setuptools` statement in `setup.py` that resulted in an error when running `python setup.py build_ext --inline`.

```
> python setup.py install
Traceback (most recent call last):
  File "setup.py", line 76, in <module>
    packages=setuptools.find_packages(),
NameError: name 'setuptools' is not defined
```

The error occurs on line 76 `packages=setuptools.find_packages()`. This PR fixes it by importing `setuptools` at the top of the script.